### PR TITLE
Update existing role message instead of creating new one

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,4 +87,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.3.7
+   2.3.15

--- a/config.example.yml
+++ b/config.example.yml
@@ -10,8 +10,7 @@ rules_channel: 1234
 
 roles:
   god: 1111
-  admin: 2222
-  botadmin: 3333
+  admin: [2222, 3333]
   disciple: 4444
 
 class_categories:

--- a/config.example.yml
+++ b/config.example.yml
@@ -5,6 +5,8 @@ prefix: "!"
 
 bot_channel: 1234
 testing_channel: 1234
+chapel_channel: 1234
+rules_channel: 1234
 
 roles:
   god: 1111

--- a/modules/admin.rb
+++ b/modules/admin.rb
@@ -88,11 +88,14 @@ module Bishop
       end
 
       command(:role_message, allowed_roles: [CONFIG['roles']['admin']]) do |event|
-        event.message.delete
+        # event.message.delete
 
-        event.send_embed do |embed, view|
-          SharedRoleComponents.add_selects(embed, view)
-        end
+        # event.send_embed do |embed, view|
+        #   SharedRoleComponents.add_selects(embed, view)
+        # end
+
+        SharedRoleComponents.update_select_message(event.bot)
+        event.message.react '✅'
       end
     end
   end

--- a/modules/admin.rb
+++ b/modules/admin.rb
@@ -11,7 +11,7 @@ module Bishop
       extend Discordrb::Commands::CommandContainer
 
       command(:update,
-              allowed_roles: [CONFIG['roles']['admin'], CONFIG['roles']['botadmin']],
+              allowed_roles: CONFIG['roles']['admin'],
               description: 'Update bot to latest commit') do |event|
         event.message.react '⌛'
 
@@ -40,14 +40,14 @@ module Bishop
       end
 
       command(:reload,
-              allowed_roles: [CONFIG['roles']['admin'], CONFIG['roles']['botadmin']],
+              allowed_roles: CONFIG['roles']['admin'],
               description: 'Reload all command containers') do |event|
         reload_modules(event.bot)
         event.message.react '✅'
       end
 
       command(:newclass,
-              allowed_roles: [CONFIG['roles']['admin']],
+              allowed_roles: CONFIG['roles']['admin'],
               description: 'Create a new class role and channel. [admin only]') do |event, name|
         return event.message.react '❓' unless name && name =~ /\w+\d+/
 
@@ -87,7 +87,7 @@ module Bishop
         end
       end
 
-      command(:role_message, allowed_roles: [CONFIG['roles']['admin']]) do |event|
+      command(:role_message, allowed_roles: CONFIG['roles']['admin']) do |event|
         # event.message.delete
 
         # event.send_embed do |embed, view|

--- a/modules/slashcommands.rb
+++ b/modules/slashcommands.rb
@@ -11,12 +11,13 @@ module Bishop
         Discordrb::LOGGER.info 'Registering /role'
 
         # if its already registered, just return and dont re-register it
-        if bot.get_application_commands(server_id: ENV['SERVER_ID']).any? { |c| c.name == 'role' }
+        if bot.get_application_commands(server_id: ENV.fetch('SERVER_ID', nil)).any? { |c| c.name == 'role' }
           Discordrb::LOGGER.info '  already registered, skipping'
           return
         end
 
-        bot.register_application_command(:role, 'Manage your class roles', server_id: ENV['SERVER_ID']) do |cmd|
+        bot.register_application_command(:role, 'Manage your class roles',
+                                         server_id: ENV.fetch('SERVER_ID', nil)) do |cmd|
           cmd.subcommand(:add, 'Select class roles to add')
           cmd.subcommand(:remove, 'Select roles to remove from yourself')
           cmd.subcommand(:list, 'List all valid class roles')

--- a/shared/role_components.rb
+++ b/shared/role_components.rb
@@ -81,4 +81,20 @@ module SharedRoleComponents
       end
     end
   end
+
+  def self.update_select_message(bot)
+    rules_channel = bot.channel(CONFIG['rules_channel'])
+    # the select message is bishop's first (and only) message in #rules
+    # select_message = rules_channel.history(10).filter { |m| m.author.id == bot.profile.id }.first
+    # but lets be smart here and check for the embed name
+    select_message = rules_channel.history(10).filter { |m| m.embeds.first.fields.first.name == 'Role Selection' }.first
+
+    # update that message with new components
+    # (edit_message does not yield, so gotta make new embed/components from scratch)
+    embed = Discordrb::Webhooks::Embed.new
+    view = Discordrb::Webhooks::View.new
+    add_selects(embed, view)
+
+    select_message.edit('', embed, view)
+  end
 end


### PR DESCRIPTION
Also combines admin and botadmin roles to allow the bot admin to update the role message.