### PR TITLE
Append ACM and App Club Discord Plugs

### DIFF
--- a/modules/general.rb
+++ b/modules/general.rb
@@ -101,6 +101,14 @@ module Bishop
         'https://discord.gg/k7FsFb2rrC 🔌'
       end
 
+      command(:osuapp, aliases: %i[app_plug]) do
+        'https://discord.gg/BfdNJ7hXdd 🔌'
+      end
+
+      command(:acm, aliases: %i[acm_plug]) do
+        'https://discord.gg/vwD9ksCqsV 🔌'
+      end
+
       command(:roll, aliases: %i[dice]) do |event, n|
         return event.message.react '❓' if n.to_i < 1
 


### PR DESCRIPTION
Hi, this PR adds Association for Computer Machinery and App Development Club discord plug commands to the bot.

```
!osuapp 
!app_plug
!acm
!acm_plug
```

Cheers! Feel free to edit if you think there's a better alias or command name.