### PR TITLE
Updated forecasting command for 2025-26 academic year

### DIFF
--- a/modules/general.rb
+++ b/modules/general.rb
@@ -94,7 +94,7 @@ module Bishop
       end
 
       command(:forecasting) do
-        'https://docs.google.com/spreadsheets/d/17BCDeoqCDgTrWwdk41nIegAyMAThWgAMYV5YE1s6sfY/htmlview'
+        'https://docs.google.com/spreadsheets/d/1tIvPdUo9_ZEGyHQqMjZLt5rYz70djzqcRU4HCeAKk4k/htmlview'
       end
 
       command(:lug, aliases: %i[plug]) do


### PR DESCRIPTION
I had replaced the Google Sheets link in `modules/general.rb` so the `!forecasting` command returns a link to the new EECS forecasting spreadsheet published for the 2025-26 academic year.